### PR TITLE
Recover restore serverPublicKey from swap tree instead of wallet seed

### DIFF
--- a/boltz-core/src/musig.rs
+++ b/boltz-core/src/musig.rs
@@ -76,6 +76,9 @@ use std::marker::PhantomData;
 /// Re-export of `secp256k1::XOnlyPublicKey` used as the aggregated MuSig2 public key.
 pub use secp256k1::XOnlyPublicKey;
 
+/// Re-export of `secp256k1::PublicKey` used for MuSig2 participant keys.
+pub use secp256k1::PublicKey as MusigPublicKey;
+
 /// Errors produced by the MuSig2 builder.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -643,6 +646,12 @@ impl Musig {
     /// Parse a serialized (33- or 65-byte) compressed/uncompressed public key.
     pub fn convert_pub_key(pub_key: &[u8]) -> Result<PublicKey, MusigError> {
         Ok(PublicKey::from_slice(pub_key)?)
+    }
+
+    /// Aggregate public keys with MuSig2 key aggregation (order-sensitive)
+    /// and return the x-only aggregated key, without opening a signing session.
+    pub fn aggregate_public_keys(pub_keys: &[PublicKey]) -> XOnlyPublicKey {
+        KeyAggCache::new(&pub_keys.iter().collect::<Vec<_>>()).agg_pk()
     }
 
     /// Parse a serialized 66-byte MuSig2 public nonce.

--- a/boltzr/src/service/rescue.rs
+++ b/boltzr/src/service/rescue.rs
@@ -15,8 +15,9 @@ use boltz_cache::Cache;
 use diesel::{BoolExpressionMethods, ExpressionMethods};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
-use tracing::{debug, instrument, trace};
+use tracing::{debug, instrument, trace, warn};
 
 trait Identifiable {
     fn id(&self) -> &str;
@@ -948,7 +949,17 @@ impl SwapRescue {
         (
             &s,
             Self::lookup_from_keys(keys_map, &s.refundPublicKey, &s.id)?,
-            Self::derive_our_public_key(secp, &chain_symbol, &wallet, &s.id(), s.keyIndex)?,
+            Self::server_public_key(
+                secp,
+                &chain_symbol,
+                &wallet,
+                &s.id,
+                s.keyIndex,
+                s.redeemScript.as_ref(),
+                true,
+                &s.refundPublicKey,
+                &s.lockupAddress,
+            )?,
             Self::derive_blinding_key(&wallet, &s.id, &chain_symbol, &s.lockupAddress)?,
         )
             .try_into()
@@ -965,12 +976,16 @@ impl SwapRescue {
         (
             &s,
             Self::lookup_from_keys(keys_map, &s.receiving().theirPublicKey, &s.id())?,
-            Self::derive_our_public_key(
+            Self::server_public_key(
                 secp,
                 &s.receiving().symbol,
                 &wallet,
                 &s.id(),
                 s.receiving().keyIndex,
+                s.receiving().swapTree.as_ref(),
+                true,
+                &s.receiving().theirPublicKey,
+                &s.receiving().lockupAddress,
             )?,
             Self::derive_blinding_key(
                 &wallet,
@@ -994,7 +1009,17 @@ impl SwapRescue {
         (
             &s,
             Self::lookup_from_keys(keys_map, &s.refundPublicKey, &s.id)?,
-            Self::derive_our_public_key(secp, &chain_symbol, &wallet, &s.id(), s.keyIndex)?,
+            Self::server_public_key(
+                secp,
+                &chain_symbol,
+                &wallet,
+                &s.id,
+                s.keyIndex,
+                s.redeemScript.as_ref(),
+                true,
+                &s.refundPublicKey,
+                &s.lockupAddress,
+            )?,
             Self::derive_blinding_key(&wallet, &s.id, &chain_symbol, &s.lockupAddress)?,
         )
             .try_into()
@@ -1026,12 +1051,16 @@ impl SwapRescue {
                 (
                     &s,
                     key_index,
-                    Self::derive_our_public_key(
+                    Self::server_public_key(
                         secp,
                         &s.sending().symbol,
                         &sending_wallet,
                         &s.id(),
                         s.sending().keyIndex,
+                        s.sending().swapTree.as_ref(),
+                        false,
+                        &s.sending().theirPublicKey,
+                        &s.sending().lockupAddress,
                     )?,
                     Self::derive_blinding_key(
                         &sending_wallet,
@@ -1052,12 +1081,16 @@ impl SwapRescue {
                 (
                     receiving_data,
                     key_index,
-                    Self::derive_our_public_key(
+                    Self::server_public_key(
                         secp,
                         &s.receiving().symbol,
                         &receiving_wallet,
                         &s.id(),
                         s.receiving().keyIndex,
+                        s.receiving().swapTree.as_ref(),
+                        true,
+                        &s.receiving().theirPublicKey,
+                        &s.receiving().lockupAddress,
                     )?,
                     Self::derive_blinding_key(
                         &receiving_wallet,
@@ -1115,7 +1148,17 @@ impl SwapRescue {
         (
             &s,
             Self::lookup_from_keys(keys_map, &s.claimPublicKey, &s.id())?,
-            Self::derive_our_public_key(secp, &chain_symbol, &wallet, &s.id(), s.keyIndex)?,
+            Self::server_public_key(
+                secp,
+                &chain_symbol,
+                &wallet,
+                &s.id,
+                s.keyIndex,
+                s.redeemScript.as_ref(),
+                false,
+                &s.claimPublicKey,
+                &s.lockupAddress,
+            )?,
             Self::derive_blinding_key(&wallet, &s.id, &chain_symbol, &s.lockupAddress)?,
         )
             .try_into()
@@ -1128,6 +1171,117 @@ impl SwapRescue {
             .wallet
             .clone()
             .ok_or_else(|| anyhow!("no wallet for {}", symbol))
+    }
+
+    /// Returns the server public key of a swap, preferring recovery from the swap's
+    /// stored taproot tree over wallet derivation. The wallet seed may not be the one
+    /// the swap was created with (e.g. after a seed loss), in which case derivation
+    /// returns a key that does not match the on-chain lockup; the tree recovery result
+    /// is verified against the lockup address, so when it succeeds it is always the
+    /// original key.
+    #[allow(clippy::too_many_arguments)]
+    fn server_public_key(
+        secp: &Secp256k1<secp256k1::All>,
+        symbol: &str,
+        wallet: &Arc<dyn Wallet + Send + Sync>,
+        id: &str,
+        key_index: Option<i32>,
+        tree_json: Option<&String>,
+        server_is_claimer: bool,
+        their_public_key: &Option<String>,
+        lockup_address: &str,
+    ) -> Result<String> {
+        if let Some(tree_json) = tree_json {
+            if let Some(key) = Self::recover_server_public_key(
+                secp,
+                tree_json,
+                server_is_claimer,
+                their_public_key,
+                lockup_address,
+            ) {
+                return Ok(key);
+            }
+
+            warn!(
+                "Could not recover server public key of {} from its swap tree; falling back to wallet derivation",
+                id
+            );
+        }
+
+        Self::derive_our_public_key(secp, symbol, wallet, id, key_index)
+    }
+
+    /// Recovers the original server public key from the swap's taproot tree.
+    /// The x-only key is read from the leaf the server signs (claim leaf when the
+    /// server is the claimer, refund leaf when it is the refunder). The parity byte
+    /// is not committed to in the leaf script, so both candidates are checked by
+    /// aggregating with the client's key and comparing the tweaked MuSig2 output key
+    /// against the lockup address. Returns `None` when the swap is not a BTC taproot
+    /// swap or nothing matches (e.g. Liquid addresses, legacy redeem scripts).
+    fn recover_server_public_key(
+        secp: &Secp256k1<secp256k1::All>,
+        tree_json: &str,
+        server_is_claimer: bool,
+        their_public_key: &Option<String>,
+        lockup_address: &str,
+    ) -> Option<String> {
+        let tree: boltz_core::bitcoin::Tree = serde_json::from_str(tree_json).ok()?;
+        let server_xonly = if server_is_claimer {
+            tree.claim_pubkey()
+        } else {
+            tree.refund_pubkey()
+        }
+        .ok()?;
+
+        let their_key = boltz_core::musig::Musig::convert_pub_key(
+            &hex::decode(their_public_key.as_ref()?).ok()?,
+        )
+        .ok()?;
+
+        let lockup_script = bitcoin::Address::from_str(lockup_address)
+            .ok()?
+            .assume_checked()
+            .script_pubkey();
+        if !lockup_script.is_p2tr() {
+            return None;
+        }
+
+        for parity in [0x02u8, 0x03] {
+            let mut candidate_bytes = [0u8; 33];
+            candidate_bytes[0] = parity;
+            candidate_bytes[1..].copy_from_slice(&server_xonly.serialize());
+
+            let candidate = match boltz_core::musig::Musig::convert_pub_key(&candidate_bytes) {
+                Ok(key) => key,
+                Err(_) => continue,
+            };
+
+            // The order the keys were aggregated in at swap creation is not
+            // recorded, so both are tried; the address comparison disambiguates.
+            for keys in [[candidate, their_key], [their_key, candidate]] {
+                let internal_key = match bitcoin::XOnlyPublicKey::from_slice(
+                    &boltz_core::musig::Musig::aggregate_public_keys(&keys).serialize(),
+                ) {
+                    Ok(key) => key,
+                    Err(_) => continue,
+                };
+
+                let spend_info = match tree
+                    .build()
+                    .ok()
+                    .and_then(|builder| builder.finalize(secp, internal_key).ok())
+                {
+                    Some(info) => info,
+                    None => continue,
+                };
+
+                if bitcoin::ScriptBuf::new_p2tr_tweaked(spend_info.output_key()) == lockup_script {
+                    return Some(hex::encode(candidate_bytes));
+                }
+            }
+        }
+
+        None
     }
 
     fn derive_our_public_key(
@@ -1293,6 +1447,116 @@ mod test {
             onchainAmount: 150000,
             createdAt: chrono::NaiveDateTime::from_str("2025-01-01T23:58:00").unwrap(),
         }
+    }
+
+    #[test]
+    fn test_recover_server_public_key() {
+        use bitcoin::absolute::LockTime;
+        use bitcoin::hashes::{Hash, hash160};
+        use boltz_core::musig::Musig;
+
+        let secp = Secp256k1::default();
+
+        let server_key = Musig::convert_keypair([0x11u8; 32]).unwrap();
+        let user_key = Musig::convert_keypair([0x22u8; 32]).unwrap();
+
+        let to_bitcoin_xonly = |key: &boltz_core::musig::MusigPublicKey| {
+            bitcoin::XOnlyPublicKey::from_slice(&key.x_only_public_key().0.serialize()).unwrap()
+        };
+
+        let preimage_hash = hash160::Hash::hash(b"such preimage");
+
+        for server_is_claimer in [true, false] {
+            let (claim_key, refund_key) = if server_is_claimer {
+                (server_key.public_key(), user_key.public_key())
+            } else {
+                (user_key.public_key(), server_key.public_key())
+            };
+
+            let tree = boltz_core::bitcoin::swap_tree(
+                preimage_hash,
+                &to_bitcoin_xonly(&claim_key),
+                &to_bitcoin_xonly(&refund_key),
+                LockTime::from_height(800_000).unwrap(),
+            );
+            let tree_json = serde_json::to_string(&tree).unwrap();
+
+            // The recovery has to work regardless of the order the keys
+            // were aggregated in when the lockup address was created
+            for agg_keys in [
+                [server_key.public_key(), user_key.public_key()],
+                [user_key.public_key(), server_key.public_key()],
+            ] {
+                let internal_key = bitcoin::XOnlyPublicKey::from_slice(
+                    &Musig::aggregate_public_keys(&agg_keys).serialize(),
+                )
+                .unwrap();
+                let spend_info = tree.build().unwrap().finalize(&secp, internal_key).unwrap();
+                let address = bitcoin::Address::p2tr_tweaked(
+                    spend_info.output_key(),
+                    bitcoin::Network::Bitcoin,
+                );
+
+                let recovered = SwapRescue::recover_server_public_key(
+                    &secp,
+                    &tree_json,
+                    server_is_claimer,
+                    &Some(hex::encode(user_key.public_key().serialize())),
+                    &address.to_string(),
+                );
+                assert_eq!(
+                    recovered,
+                    Some(hex::encode(server_key.public_key().serialize()))
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_recover_server_public_key_wrong_address() {
+        use bitcoin::absolute::LockTime;
+        use bitcoin::hashes::{Hash, hash160};
+        use boltz_core::musig::Musig;
+
+        let secp = Secp256k1::default();
+
+        let server_key = Musig::convert_keypair([0x11u8; 32]).unwrap();
+        let user_key = Musig::convert_keypair([0x22u8; 32]).unwrap();
+
+        let tree = boltz_core::bitcoin::swap_tree(
+            hash160::Hash::hash(b"such preimage"),
+            &bitcoin::XOnlyPublicKey::from_slice(
+                &server_key.public_key().x_only_public_key().0.serialize(),
+            )
+            .unwrap(),
+            &bitcoin::XOnlyPublicKey::from_slice(
+                &user_key.public_key().x_only_public_key().0.serialize(),
+            )
+            .unwrap(),
+            LockTime::from_height(800_000).unwrap(),
+        );
+
+        // A valid taproot address the tree and keys do not tweak to
+        let unrelated_address = bitcoin::Address::p2tr(
+            &secp,
+            bitcoin::XOnlyPublicKey::from_slice(
+                &user_key.public_key().x_only_public_key().0.serialize(),
+            )
+            .unwrap(),
+            None,
+            bitcoin::Network::Bitcoin,
+        );
+
+        assert_eq!(
+            SwapRescue::recover_server_public_key(
+                &secp,
+                &serde_json::to_string(&tree).unwrap(),
+                true,
+                &Some(hex::encode(user_key.public_key().serialize())),
+                &unrelated_address.to_string(),
+            ),
+            None
+        );
     }
 
     #[tokio::test]

--- a/boltzr/src/service/rescue.rs
+++ b/boltzr/src/service/rescue.rs
@@ -944,15 +944,13 @@ impl SwapRescue {
         s: Swap,
     ) -> Result<RescuableSwap> {
         let chain_symbol = s.chain_symbol()?;
-        let wallet = self.get_wallet(&chain_symbol)?;
 
         (
             &s,
             Self::lookup_from_keys(keys_map, &s.refundPublicKey, &s.id)?,
-            Self::server_public_key(
+            self.server_public_key(
                 secp,
                 &chain_symbol,
-                &wallet,
                 &s.id,
                 s.keyIndex,
                 s.redeemScript.as_ref(),
@@ -960,7 +958,7 @@ impl SwapRescue {
                 &s.refundPublicKey,
                 &s.lockupAddress,
             )?,
-            Self::derive_blinding_key(&wallet, &s.id, &chain_symbol, &s.lockupAddress)?,
+            self.derive_blinding_key(&s.id, &chain_symbol, &s.lockupAddress)?,
         )
             .try_into()
     }
@@ -971,15 +969,12 @@ impl SwapRescue {
         keys_map: &HashMap<String, u32>,
         s: ChainSwapInfo,
     ) -> Result<RescuableSwap> {
-        let wallet = self.get_wallet(&s.receiving().symbol)?;
-
         (
             &s,
             Self::lookup_from_keys(keys_map, &s.receiving().theirPublicKey, &s.id())?,
-            Self::server_public_key(
+            self.server_public_key(
                 secp,
                 &s.receiving().symbol,
-                &wallet,
                 &s.id(),
                 s.receiving().keyIndex,
                 s.receiving().swapTree.as_ref(),
@@ -987,12 +982,7 @@ impl SwapRescue {
                 &s.receiving().theirPublicKey,
                 &s.receiving().lockupAddress,
             )?,
-            Self::derive_blinding_key(
-                &wallet,
-                &s.id(),
-                &s.receiving().symbol,
-                &s.receiving().lockupAddress,
-            )?,
+            self.derive_blinding_key(&s.id(), &s.receiving().symbol, &s.receiving().lockupAddress)?,
         )
             .try_into()
     }
@@ -1004,15 +994,13 @@ impl SwapRescue {
         s: Swap,
     ) -> Result<RestorableSwap> {
         let chain_symbol = s.chain_symbol()?;
-        let wallet = self.get_wallet(&chain_symbol)?;
 
         (
             &s,
             Self::lookup_from_keys(keys_map, &s.refundPublicKey, &s.id)?,
-            Self::server_public_key(
+            self.server_public_key(
                 secp,
                 &chain_symbol,
-                &wallet,
                 &s.id,
                 s.keyIndex,
                 s.redeemScript.as_ref(),
@@ -1020,7 +1008,7 @@ impl SwapRescue {
                 &s.refundPublicKey,
                 &s.lockupAddress,
             )?,
-            Self::derive_blinding_key(&wallet, &s.id, &chain_symbol, &s.lockupAddress)?,
+            self.derive_blinding_key(&s.id, &chain_symbol, &s.lockupAddress)?,
         )
             .try_into()
     }
@@ -1046,15 +1034,13 @@ impl SwapRescue {
         } else if let Some(key_index) =
             Self::lookup_optional_from_keys(keys_map, &sending_data.theirPublicKey)
         {
-            let sending_wallet = self.get_wallet(&sending_data.symbol)?;
             Some(ClaimDetails::Utxo(
                 (
                     &s,
                     key_index,
-                    Self::server_public_key(
+                    self.server_public_key(
                         secp,
                         &s.sending().symbol,
-                        &sending_wallet,
                         &s.id(),
                         s.sending().keyIndex,
                         s.sending().swapTree.as_ref(),
@@ -1062,8 +1048,7 @@ impl SwapRescue {
                         &s.sending().theirPublicKey,
                         &s.sending().lockupAddress,
                     )?,
-                    Self::derive_blinding_key(
-                        &sending_wallet,
+                    self.derive_blinding_key(
                         &s.id(),
                         &s.sending().symbol,
                         &s.sending().lockupAddress,
@@ -1076,15 +1061,13 @@ impl SwapRescue {
         };
 
         let refund_details = if let Some(key_index) = refund_key_index {
-            let receiving_wallet = self.get_wallet(&receiving_data.symbol)?;
             Some(RefundDetails::Utxo(Box::new(
                 (
                     receiving_data,
                     key_index,
-                    Self::server_public_key(
+                    self.server_public_key(
                         secp,
                         &s.receiving().symbol,
-                        &receiving_wallet,
                         &s.id(),
                         s.receiving().keyIndex,
                         s.receiving().swapTree.as_ref(),
@@ -1092,8 +1075,7 @@ impl SwapRescue {
                         &s.receiving().theirPublicKey,
                         &s.receiving().lockupAddress,
                     )?,
-                    Self::derive_blinding_key(
-                        &receiving_wallet,
+                    self.derive_blinding_key(
                         &s.id(),
                         &s.receiving().symbol,
                         &s.receiving().lockupAddress,
@@ -1143,15 +1125,12 @@ impl SwapRescue {
             });
         }
 
-        let wallet = self.get_wallet(&chain_symbol)?;
-
         (
             &s,
             Self::lookup_from_keys(keys_map, &s.claimPublicKey, &s.id())?,
-            Self::server_public_key(
+            self.server_public_key(
                 secp,
                 &chain_symbol,
-                &wallet,
                 &s.id,
                 s.keyIndex,
                 s.redeemScript.as_ref(),
@@ -1159,7 +1138,7 @@ impl SwapRescue {
                 &s.claimPublicKey,
                 &s.lockupAddress,
             )?,
-            Self::derive_blinding_key(&wallet, &s.id, &chain_symbol, &s.lockupAddress)?,
+            self.derive_blinding_key(&s.id, &chain_symbol, &s.lockupAddress)?,
         )
             .try_into()
     }
@@ -1181,9 +1160,9 @@ impl SwapRescue {
     /// original key.
     #[allow(clippy::too_many_arguments)]
     fn server_public_key(
+        &self,
         secp: &Secp256k1<secp256k1::All>,
         symbol: &str,
-        wallet: &Arc<dyn Wallet + Send + Sync>,
         id: &str,
         key_index: Option<i32>,
         tree_json: Option<&String>,
@@ -1208,7 +1187,10 @@ impl SwapRescue {
             );
         }
 
-        Self::derive_our_public_key(secp, symbol, wallet, id, key_index)
+        // The wallet is only needed for the fallback; fetched lazily so
+        // recovery also works for currencies without a wallet configured
+        let wallet = self.get_wallet(symbol)?;
+        Self::derive_our_public_key(secp, symbol, &wallet, id, key_index)
     }
 
     /// Recovers the original server public key from the swap's taproot tree.
@@ -1311,16 +1293,12 @@ impl SwapRescue {
         }
     }
 
-    fn derive_blinding_key(
-        wallet: &Arc<dyn Wallet + Send + Sync>,
-        id: &str,
-        symbol: &str,
-        address: &str,
-    ) -> Result<Option<String>> {
+    fn derive_blinding_key(&self, id: &str, symbol: &str, address: &str) -> Result<Option<String>> {
         if symbol != crate::chain::elements_client::SYMBOL {
             return Ok(None);
         }
 
+        let wallet = self.get_wallet(symbol)?;
         Ok(Some(hex::encode(
             wallet
                 .derive_blinding_key(wallet.decode_address(address)?)
@@ -1509,6 +1487,84 @@ mod test {
                     Some(hex::encode(server_key.public_key().serialize()))
                 );
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_restorable_swap_recovery_without_wallet() {
+        use bitcoin::absolute::LockTime;
+        use bitcoin::hashes::{Hash, hash160};
+        use boltz_core::musig::Musig;
+
+        let secp = Secp256k1::default();
+
+        let server_key = Musig::convert_keypair([0x11u8; 32]).unwrap();
+        let user_key = Musig::convert_keypair([0x22u8; 32]).unwrap();
+        let user_key_hex = hex::encode(user_key.public_key().serialize());
+
+        let to_bitcoin_xonly = |key: &boltz_core::musig::MusigPublicKey| {
+            bitcoin::XOnlyPublicKey::from_slice(&key.x_only_public_key().0.serialize()).unwrap()
+        };
+
+        let tree = boltz_core::bitcoin::swap_tree(
+            hash160::Hash::hash(b"such preimage"),
+            &to_bitcoin_xonly(&server_key.public_key()),
+            &to_bitcoin_xonly(&user_key.public_key()),
+            LockTime::from_height(800_000).unwrap(),
+        );
+        let internal_key = bitcoin::XOnlyPublicKey::from_slice(
+            &Musig::aggregate_public_keys(&[server_key.public_key(), user_key.public_key()])
+                .serialize(),
+        )
+        .unwrap();
+        let spend_info = tree.build().unwrap().finalize(&secp, internal_key).unwrap();
+        let lockup_address =
+            bitcoin::Address::p2tr_tweaked(spend_info.output_key(), bitcoin::Network::Bitcoin);
+
+        let swap = Swap {
+            pair: "BTC/BTC".to_string(),
+            refundPublicKey: Some(user_key_hex.clone()),
+            redeemScript: Some(serde_json::to_string(&tree).unwrap()),
+            lockupAddress: lockup_address.to_string(),
+            ..get_test_swap(String::new())
+        };
+
+        // A BTC currency WITHOUT a wallet: recovery from the tree must
+        // still work as the wallet is only needed for fallback derivation
+        let rescue = SwapRescue::new(
+            Cache::Memory(MemCache::new()),
+            Arc::new(MockSwapHelper::new()),
+            Arc::new(MockChainSwapHelper::new()),
+            Arc::new(MockReverseSwapHelper::new()),
+            Arc::new(HashMap::from([(
+                "BTC".to_string(),
+                Currency {
+                    network: Network::Regtest,
+                    wallet: None,
+                    chain: None,
+                    cln: None,
+                    lnds: HashMap::new(),
+                    evm_manager: None,
+                },
+            )])),
+            Arc::new(MockSwapMetadataHelper::new()),
+        );
+
+        let keys_map = HashMap::from([(user_key_hex, 21u32)]);
+        let restored = rescue
+            .create_restorable_swap(&secp, &keys_map, swap)
+            .unwrap();
+
+        match restored.refund_details {
+            Some(RefundDetails::Utxo(details)) => {
+                assert_eq!(
+                    details.server_public_key,
+                    hex::encode(server_key.public_key().serialize())
+                );
+                assert_eq!(details.key_index, 21);
+                assert_eq!(details.blinding_key, None);
+            }
+            _ => panic!("expected UTXO refund details"),
         }
     }
 
@@ -2361,10 +2417,30 @@ swapTree: Some(tree.clone()),
         );
     }
 
+    fn get_liquid_rescue() -> SwapRescue {
+        SwapRescue::new(
+            Cache::Memory(MemCache::new()),
+            Arc::new(MockSwapHelper::new()),
+            Arc::new(MockChainSwapHelper::new()),
+            Arc::new(MockReverseSwapHelper::new()),
+            Arc::new(HashMap::from([(
+                crate::chain::elements_client::SYMBOL.to_string(),
+                Currency {
+                    network: Network::Regtest,
+                    wallet: Some(get_liquid_wallet()),
+                    chain: None,
+                    cln: None,
+                    lnds: HashMap::new(),
+                    evm_manager: None,
+                },
+            )])),
+            Arc::new(MockSwapMetadataHelper::new()),
+        )
+    }
+
     #[tokio::test]
     async fn test_derive_blinding_key() {
-        assert_eq!(SwapRescue::derive_blinding_key(
-            &get_liquid_wallet(),
+        assert_eq!(get_liquid_rescue().derive_blinding_key(
             "",
             crate::chain::elements_client::SYMBOL,
             "el1pqt0dzt0mh2gxxvrezmzqexg0n66rkmd5997wn255wmfpqdegd2qyh284rq5v4h2vtj0ey3399k8d8v8qwsphj3qt4cf9zj08h0zqhraf0qcqltm5nfxq",
@@ -2374,7 +2450,8 @@ swapTree: Some(tree.clone()),
     #[tokio::test]
     async fn test_derive_blinding_key_non_liquid() {
         assert!(
-            SwapRescue::derive_blinding_key(&get_liquid_wallet(), "", "BTC", "")
+            get_liquid_rescue()
+                .derive_blinding_key("", "BTC", "")
                 .unwrap()
                 .is_none()
         );


### PR DESCRIPTION
## Why

The original `seed.dat` is lost; the backend runs on a throwaway seed with all signers disabled (refund-only wind-down). `/v2/swap/restore` and `/v2/swap/rescue` derived `serverPublicKey` from the live wallet at `keyIndex`, so every returned key was wrong — while `tree`, `lockupAddress`, and `timeoutBlockHeight` from the DB were correct. Clients need the real server key to aggregate the MuSig2 internal key and build the control block for unilateral script-path refunds.

## What

- `boltzr/src/service/rescue.rs`: new `server_public_key` → `recover_server_public_key`. Reads the original server key's x-only bytes from the stored taproot tree (claim leaf for submarine/chain-receiving, refund leaf for reverse/chain-sending), then brute-forces the parity byte and key-aggregation order by checking which candidate MuSig2 aggregate, tweaked with the tree, reproduces the actual `lockupAddress`. A match is cryptographically guaranteed to be the original key — this is strictly more reliable than wallet derivation even with the right seed.
- Falls back to the previous wallet derivation (with a warn log) when recovery isn't possible: EVM rows, Liquid addresses, legacy redeem scripts.
- `boltz-core/src/musig.rs`: adds `Musig::aggregate_public_keys` (KeyAgg without opening a signing session) and re-exports `PublicKey` as `MusigPublicKey`.
- All call sites updated: submarine, reverse, and both chain-swap sides, for both rescue and restore flows.

## Testing

- New: `test_recover_server_public_key` round-trips a real taproot tree with the server key in both leaf positions and both aggregation orders; `test_recover_server_public_key_wrong_address` asserts no false positive against a valid but unrelated P2TR address.
- All 32 existing `service::rescue` tests and 11 `musig` tests pass; clippy and fmt clean.
- `cargo test -p boltzr test_recover`

🤖 Generated with [Claude Code](https://claude.com/claude-code)